### PR TITLE
removed --no-quarantine option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or download from [Releases](../../releases/latest), unzip, drag to `/Application
 xattr -c /Applications/HopTab.app
 ```
 
-> **Why xattr?** HopTab is ad-hoc signed (not notarized). The command clears macOS's quarantine flag so it opens normally. Homebrew's `--no-quarantine` flag handles this automatically.
+> **Why xattr?** HopTab is ad-hoc signed (not notarized). The command clears macOS's quarantine flag so it opens normally.
 
 ### First Launch
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pin apps. Tile windows to halves, thirds, quarters. Switch profiles per desktop.
 
 ```bash
 brew tap royalbhati/tap
-brew install --cask --no-quarantine hoptab
+brew install --cask hoptab
 ```
 
 ### Manual


### PR DESCRIPTION
removed --no-quarantine option as it is deprecated and disabled in homebrew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the Homebrew installation instruction in the README for a clearer, shorter install command.
  * Updated the accompanying explanation to remove an incorrect claim about Homebrew handling quarantine automatically and clarified the rationale for the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->